### PR TITLE
[fix]更新rtconfig.py支持各平台编译

### DIFF
--- a/projects/01_kernel/rtconfig.py
+++ b/projects/01_kernel/rtconfig.py
@@ -1,5 +1,7 @@
 import os
+import platform
 
+system_name = platform.system()
 # toolchains options
 ARCH='arm'
 CPU='cortex-m4'
@@ -15,9 +17,19 @@ if os.getenv('RTT_ROOT'):
 
 # cross_tool provides the cross compiler
 # EXEC_PATH is the compiler execute path, for example, CodeSourcery, Keil MDK, IAR
-if  CROSS_TOOL == 'gcc':
-    PLATFORM    = 'gcc'
-    EXEC_PATH   = r'C:\Users\XXYYZZ'
+if CROSS_TOOL == "gcc":
+    PLATFORM = "gcc"
+    # Linux
+    if system_name == "Linux":
+        EXEC_PATH = r"/usr/bin"
+    # Macos
+    elif system_name == "Darwin":
+        EXEC_PATH = r"/opt/homebrew/bin/"
+    # Windows
+    elif system_name == "Windows":
+        EXEC_PATH = r"C:\Users\XXYYZZ"
+    else:
+        EXEC_PATH = r"/usr/bin"
 elif CROSS_TOOL == 'keil':
     PLATFORM    = 'armcc'
     EXEC_PATH   = r'C:/Keil_v5'
@@ -73,7 +85,7 @@ elif PLATFORM == 'armcc':
     DEVICE = ' --cpu Cortex-M4.fp '
     CFLAGS = '-c ' + DEVICE + ' --apcs=interwork --c99'
     AFLAGS = DEVICE + ' --apcs=interwork '
-    LFLAGS = DEVICE + ' --scatter "board\linker_scripts\link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
+    LFLAGS = DEVICE + ' --scatter "board/linker_scripts/link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
     CFLAGS += ' -I' + EXEC_PATH + '/ARM/ARMCC/include'
     LFLAGS += ' --libpath=' + EXEC_PATH + '/ARM/ARMCC/lib'
 
@@ -121,7 +133,6 @@ elif PLATFORM == 'armclang':
         AFLAGS += ' -g'
     else:
         CFLAGS += ' -O2'
-        
     CXXFLAGS = CFLAGS
     CFLAGS += ' -std=c99'
 
@@ -172,7 +183,6 @@ elif PLATFORM == 'iccarm':
     LFLAGS += ' --entry __iar_program_start'
 
     CXXFLAGS = CFLAGS
-    
     EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool --bin $TARGET rtthread.bin'
 

--- a/projects/02_basic_ir/rtconfig.py
+++ b/projects/02_basic_ir/rtconfig.py
@@ -1,5 +1,7 @@
 import os
+import platform
 
+system_name = platform.system()
 # toolchains options
 ARCH='arm'
 CPU='cortex-m4'
@@ -15,9 +17,19 @@ if os.getenv('RTT_ROOT'):
 
 # cross_tool provides the cross compiler
 # EXEC_PATH is the compiler execute path, for example, CodeSourcery, Keil MDK, IAR
-if  CROSS_TOOL == 'gcc':
-    PLATFORM    = 'gcc'
-    EXEC_PATH   = r'C:\Users\XXYYZZ'
+if CROSS_TOOL == "gcc":
+    PLATFORM = "gcc"
+    # Linux
+    if system_name == "Linux":
+        EXEC_PATH = r"/usr/bin"
+    # Macos
+    elif system_name == "Darwin":
+        EXEC_PATH = r"/opt/homebrew/bin/"
+    # Windows
+    elif system_name == "Windows":
+        EXEC_PATH = r"C:\Users\XXYYZZ"
+    else:
+        EXEC_PATH = r"/usr/bin"
 elif CROSS_TOOL == 'keil':
     PLATFORM    = 'armcc'
     EXEC_PATH   = r'C:/Keil_v5'
@@ -73,7 +85,7 @@ elif PLATFORM == 'armcc':
     DEVICE = ' --cpu Cortex-M4.fp '
     CFLAGS = '-c ' + DEVICE + ' --apcs=interwork --c99'
     AFLAGS = DEVICE + ' --apcs=interwork '
-    LFLAGS = DEVICE + ' --scatter "board\linker_scripts\link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
+    LFLAGS = DEVICE + ' --scatter "board/linker_scripts/link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
     CFLAGS += ' -I' + EXEC_PATH + '/ARM/ARMCC/include'
     LFLAGS += ' --libpath=' + EXEC_PATH + '/ARM/ARMCC/lib'
 
@@ -121,7 +133,6 @@ elif PLATFORM == 'armclang':
         AFLAGS += ' -g'
     else:
         CFLAGS += ' -O2'
-        
     CXXFLAGS = CFLAGS
     CFLAGS += ' -std=c99'
 
@@ -172,7 +183,6 @@ elif PLATFORM == 'iccarm':
     LFLAGS += ' --entry __iar_program_start'
 
     CXXFLAGS = CFLAGS
-    
     EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool --bin $TARGET rtthread.bin'
 

--- a/projects/02_basic_irq_beep/rtconfig.py
+++ b/projects/02_basic_irq_beep/rtconfig.py
@@ -1,5 +1,7 @@
 import os
+import platform
 
+system_name = platform.system()
 # toolchains options
 ARCH='arm'
 CPU='cortex-m4'
@@ -15,9 +17,19 @@ if os.getenv('RTT_ROOT'):
 
 # cross_tool provides the cross compiler
 # EXEC_PATH is the compiler execute path, for example, CodeSourcery, Keil MDK, IAR
-if  CROSS_TOOL == 'gcc':
-    PLATFORM    = 'gcc'
-    EXEC_PATH   = r'C:\Users\XXYYZZ'
+if CROSS_TOOL == "gcc":
+    PLATFORM = "gcc"
+    # Linux
+    if system_name == "Linux":
+        EXEC_PATH = r"/usr/bin"
+    # Macos
+    elif system_name == "Darwin":
+        EXEC_PATH = r"/opt/homebrew/bin/"
+    # Windows
+    elif system_name == "Windows":
+        EXEC_PATH = r"C:\Users\XXYYZZ"
+    else:
+        EXEC_PATH = r"/usr/bin"
 elif CROSS_TOOL == 'keil':
     PLATFORM    = 'armcc'
     EXEC_PATH   = r'C:/Keil_v5'
@@ -73,7 +85,7 @@ elif PLATFORM == 'armcc':
     DEVICE = ' --cpu Cortex-M4.fp '
     CFLAGS = '-c ' + DEVICE + ' --apcs=interwork --c99'
     AFLAGS = DEVICE + ' --apcs=interwork '
-    LFLAGS = DEVICE + ' --scatter "board\linker_scripts\link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
+    LFLAGS = DEVICE + ' --scatter "board/linker_scripts/link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
     CFLAGS += ' -I' + EXEC_PATH + '/ARM/ARMCC/include'
     LFLAGS += ' --libpath=' + EXEC_PATH + '/ARM/ARMCC/lib'
 
@@ -121,7 +133,6 @@ elif PLATFORM == 'armclang':
         AFLAGS += ' -g'
     else:
         CFLAGS += ' -O2'
-        
     CXXFLAGS = CFLAGS
     CFLAGS += ' -std=c99'
 
@@ -172,7 +183,6 @@ elif PLATFORM == 'iccarm':
     LFLAGS += ' --entry __iar_program_start'
 
     CXXFLAGS = CFLAGS
-    
     EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool --bin $TARGET rtthread.bin'
 

--- a/projects/02_basic_key/rtconfig.py
+++ b/projects/02_basic_key/rtconfig.py
@@ -1,5 +1,7 @@
 import os
+import platform
 
+system_name = platform.system()
 # toolchains options
 ARCH='arm'
 CPU='cortex-m4'
@@ -15,9 +17,19 @@ if os.getenv('RTT_ROOT'):
 
 # cross_tool provides the cross compiler
 # EXEC_PATH is the compiler execute path, for example, CodeSourcery, Keil MDK, IAR
-if  CROSS_TOOL == 'gcc':
-    PLATFORM    = 'gcc'
-    EXEC_PATH   = r'C:\Users\XXYYZZ'
+if CROSS_TOOL == "gcc":
+    PLATFORM = "gcc"
+    # Linux
+    if system_name == "Linux":
+        EXEC_PATH = r"/usr/bin"
+    # Macos
+    elif system_name == "Darwin":
+        EXEC_PATH = r"/opt/homebrew/bin/"
+    # Windows
+    elif system_name == "Windows":
+        EXEC_PATH = r"C:\Users\XXYYZZ"
+    else:
+        EXEC_PATH = r"/usr/bin"
 elif CROSS_TOOL == 'keil':
     PLATFORM    = 'armcc'
     EXEC_PATH   = r'C:/Keil_v5'
@@ -73,7 +85,7 @@ elif PLATFORM == 'armcc':
     DEVICE = ' --cpu Cortex-M4.fp '
     CFLAGS = '-c ' + DEVICE + ' --apcs=interwork --c99'
     AFLAGS = DEVICE + ' --apcs=interwork '
-    LFLAGS = DEVICE + ' --scatter "board\linker_scripts\link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
+    LFLAGS = DEVICE + ' --scatter "board/linker_scripts/link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
     CFLAGS += ' -I' + EXEC_PATH + '/ARM/ARMCC/include'
     LFLAGS += ' --libpath=' + EXEC_PATH + '/ARM/ARMCC/lib'
 
@@ -121,7 +133,6 @@ elif PLATFORM == 'armclang':
         AFLAGS += ' -g'
     else:
         CFLAGS += ' -O2'
-        
     CXXFLAGS = CFLAGS
     CFLAGS += ' -std=c99'
 
@@ -172,7 +183,6 @@ elif PLATFORM == 'iccarm':
     LFLAGS += ' --entry __iar_program_start'
 
     CXXFLAGS = CFLAGS
-    
     EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool --bin $TARGET rtthread.bin'
 

--- a/projects/02_basic_led_blink/rtconfig.py
+++ b/projects/02_basic_led_blink/rtconfig.py
@@ -1,5 +1,7 @@
 import os
+import platform
 
+system_name = platform.system()
 # toolchains options
 ARCH='arm'
 CPU='cortex-m4'
@@ -15,9 +17,19 @@ if os.getenv('RTT_ROOT'):
 
 # cross_tool provides the cross compiler
 # EXEC_PATH is the compiler execute path, for example, CodeSourcery, Keil MDK, IAR
-if  CROSS_TOOL == 'gcc':
-    PLATFORM    = 'gcc'
-    EXEC_PATH   = r'C:\Users\XXYYZZ'
+if CROSS_TOOL == "gcc":
+    PLATFORM = "gcc"
+    # Linux
+    if system_name == "Linux":
+        EXEC_PATH = r"/usr/bin"
+    # Macos
+    elif system_name == "Darwin":
+        EXEC_PATH = r"/opt/homebrew/bin/"
+    # Windows
+    elif system_name == "Windows":
+        EXEC_PATH = r"C:\Users\XXYYZZ"
+    else:
+        EXEC_PATH = r"/usr/bin"
 elif CROSS_TOOL == 'keil':
     PLATFORM    = 'armcc'
     EXEC_PATH   = r'C:/Keil_v5'
@@ -73,7 +85,7 @@ elif PLATFORM == 'armcc':
     DEVICE = ' --cpu Cortex-M4.fp '
     CFLAGS = '-c ' + DEVICE + ' --apcs=interwork --c99'
     AFLAGS = DEVICE + ' --apcs=interwork '
-    LFLAGS = DEVICE + ' --scatter "board\linker_scripts\link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
+    LFLAGS = DEVICE + ' --scatter "board/linker_scripts/link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
     CFLAGS += ' -I' + EXEC_PATH + '/ARM/ARMCC/include'
     LFLAGS += ' --libpath=' + EXEC_PATH + '/ARM/ARMCC/lib'
 
@@ -121,7 +133,6 @@ elif PLATFORM == 'armclang':
         AFLAGS += ' -g'
     else:
         CFLAGS += ' -O2'
-        
     CXXFLAGS = CFLAGS
     CFLAGS += ' -std=c99'
 
@@ -172,7 +183,6 @@ elif PLATFORM == 'iccarm':
     LFLAGS += ' --entry __iar_program_start'
 
     CXXFLAGS = CFLAGS
-    
     EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool --bin $TARGET rtthread.bin'
 

--- a/projects/02_basic_rgb_led/rtconfig.py
+++ b/projects/02_basic_rgb_led/rtconfig.py
@@ -1,5 +1,7 @@
 import os
+import platform
 
+system_name = platform.system()
 # toolchains options
 ARCH='arm'
 CPU='cortex-m4'
@@ -15,9 +17,19 @@ if os.getenv('RTT_ROOT'):
 
 # cross_tool provides the cross compiler
 # EXEC_PATH is the compiler execute path, for example, CodeSourcery, Keil MDK, IAR
-if  CROSS_TOOL == 'gcc':
-    PLATFORM    = 'gcc'
-    EXEC_PATH   = r'C:\Users\XXYYZZ'
+if CROSS_TOOL == "gcc":
+    PLATFORM = "gcc"
+    # Linux
+    if system_name == "Linux":
+        EXEC_PATH = r"/usr/bin"
+    # Macos
+    elif system_name == "Darwin":
+        EXEC_PATH = r"/opt/homebrew/bin/"
+    # Windows
+    elif system_name == "Windows":
+        EXEC_PATH = r"C:\Users\XXYYZZ"
+    else:
+        EXEC_PATH = r"/usr/bin"
 elif CROSS_TOOL == 'keil':
     PLATFORM    = 'armcc'
     EXEC_PATH   = r'C:/Keil_v5'
@@ -73,7 +85,7 @@ elif PLATFORM == 'armcc':
     DEVICE = ' --cpu Cortex-M4.fp '
     CFLAGS = '-c ' + DEVICE + ' --apcs=interwork --c99'
     AFLAGS = DEVICE + ' --apcs=interwork '
-    LFLAGS = DEVICE + ' --scatter "board\linker_scripts\link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
+    LFLAGS = DEVICE + ' --scatter "board/linker_scripts/link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
     CFLAGS += ' -I' + EXEC_PATH + '/ARM/ARMCC/include'
     LFLAGS += ' --libpath=' + EXEC_PATH + '/ARM/ARMCC/lib'
 
@@ -121,7 +133,6 @@ elif PLATFORM == 'armclang':
         AFLAGS += ' -g'
     else:
         CFLAGS += ' -O2'
-        
     CXXFLAGS = CFLAGS
     CFLAGS += ' -std=c99'
 
@@ -172,7 +183,6 @@ elif PLATFORM == 'iccarm':
     LFLAGS += ' --entry __iar_program_start'
 
     CXXFLAGS = CFLAGS
-    
     EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool --bin $TARGET rtthread.bin'
 

--- a/projects/02_basic_rtc/rtconfig.py
+++ b/projects/02_basic_rtc/rtconfig.py
@@ -1,5 +1,7 @@
 import os
+import platform
 
+system_name = platform.system()
 # toolchains options
 ARCH='arm'
 CPU='cortex-m4'
@@ -15,9 +17,19 @@ if os.getenv('RTT_ROOT'):
 
 # cross_tool provides the cross compiler
 # EXEC_PATH is the compiler execute path, for example, CodeSourcery, Keil MDK, IAR
-if  CROSS_TOOL == 'gcc':
-    PLATFORM    = 'gcc'
-    EXEC_PATH   = r'C:\Users\XXYYZZ'
+if CROSS_TOOL == "gcc":
+    PLATFORM = "gcc"
+    # Linux
+    if system_name == "Linux":
+        EXEC_PATH = r"/usr/bin"
+    # Macos
+    elif system_name == "Darwin":
+        EXEC_PATH = r"/opt/homebrew/bin/"
+    # Windows
+    elif system_name == "Windows":
+        EXEC_PATH = r"C:\Users\XXYYZZ"
+    else:
+        EXEC_PATH = r"/usr/bin"
 elif CROSS_TOOL == 'keil':
     PLATFORM    = 'armcc'
     EXEC_PATH   = r'C:/Keil_v5'
@@ -73,7 +85,7 @@ elif PLATFORM == 'armcc':
     DEVICE = ' --cpu Cortex-M4.fp '
     CFLAGS = '-c ' + DEVICE + ' --apcs=interwork --c99'
     AFLAGS = DEVICE + ' --apcs=interwork '
-    LFLAGS = DEVICE + ' --scatter "board\linker_scripts\link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
+    LFLAGS = DEVICE + ' --scatter "board/linker_scripts/link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
     CFLAGS += ' -I' + EXEC_PATH + '/ARM/ARMCC/include'
     LFLAGS += ' --libpath=' + EXEC_PATH + '/ARM/ARMCC/lib'
 
@@ -121,7 +133,6 @@ elif PLATFORM == 'armclang':
         AFLAGS += ' -g'
     else:
         CFLAGS += ' -O2'
-        
     CXXFLAGS = CFLAGS
     CFLAGS += ' -std=c99'
 
@@ -172,7 +183,6 @@ elif PLATFORM == 'iccarm':
     LFLAGS += ' --entry __iar_program_start'
 
     CXXFLAGS = CFLAGS
-    
     EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool --bin $TARGET rtthread.bin'
 

--- a/projects/03_driver_als_ps/rtconfig.py
+++ b/projects/03_driver_als_ps/rtconfig.py
@@ -1,5 +1,7 @@
 import os
+import platform
 
+system_name = platform.system()
 # toolchains options
 ARCH='arm'
 CPU='cortex-m4'
@@ -15,9 +17,19 @@ if os.getenv('RTT_ROOT'):
 
 # cross_tool provides the cross compiler
 # EXEC_PATH is the compiler execute path, for example, CodeSourcery, Keil MDK, IAR
-if  CROSS_TOOL == 'gcc':
-    PLATFORM    = 'gcc'
-    EXEC_PATH   = r'C:\Users\XXYYZZ'
+if CROSS_TOOL == "gcc":
+    PLATFORM = "gcc"
+    # Linux
+    if system_name == "Linux":
+        EXEC_PATH = r"/usr/bin"
+    # Macos
+    elif system_name == "Darwin":
+        EXEC_PATH = r"/opt/homebrew/bin/"
+    # Windows
+    elif system_name == "Windows":
+        EXEC_PATH = r"C:\Users\XXYYZZ"
+    else:
+        EXEC_PATH = r"/usr/bin"
 elif CROSS_TOOL == 'keil':
     PLATFORM    = 'armcc'
     EXEC_PATH   = r'C:/Keil_v5'
@@ -73,7 +85,7 @@ elif PLATFORM == 'armcc':
     DEVICE = ' --cpu Cortex-M4.fp '
     CFLAGS = '-c ' + DEVICE + ' --apcs=interwork --c99'
     AFLAGS = DEVICE + ' --apcs=interwork '
-    LFLAGS = DEVICE + ' --scatter "board\linker_scripts\link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
+    LFLAGS = DEVICE + ' --scatter "board/linker_scripts/link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
     CFLAGS += ' -I' + EXEC_PATH + '/ARM/ARMCC/include'
     LFLAGS += ' --libpath=' + EXEC_PATH + '/ARM/ARMCC/lib'
 
@@ -121,7 +133,6 @@ elif PLATFORM == 'armclang':
         AFLAGS += ' -g'
     else:
         CFLAGS += ' -O2'
-        
     CXXFLAGS = CFLAGS
     CFLAGS += ' -std=c99'
 
@@ -172,7 +183,6 @@ elif PLATFORM == 'iccarm':
     LFLAGS += ' --entry __iar_program_start'
 
     CXXFLAGS = CFLAGS
-    
     EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool --bin $TARGET rtthread.bin'
 

--- a/projects/03_driver_axis/rtconfig.py
+++ b/projects/03_driver_axis/rtconfig.py
@@ -1,5 +1,7 @@
 import os
+import platform
 
+system_name = platform.system()
 # toolchains options
 ARCH='arm'
 CPU='cortex-m4'
@@ -15,9 +17,19 @@ if os.getenv('RTT_ROOT'):
 
 # cross_tool provides the cross compiler
 # EXEC_PATH is the compiler execute path, for example, CodeSourcery, Keil MDK, IAR
-if  CROSS_TOOL == 'gcc':
-    PLATFORM    = 'gcc'
-    EXEC_PATH   = r'C:\Users\XXYYZZ'
+if CROSS_TOOL == "gcc":
+    PLATFORM = "gcc"
+    # Linux
+    if system_name == "Linux":
+        EXEC_PATH = r"/usr/bin"
+    # Macos
+    elif system_name == "Darwin":
+        EXEC_PATH = r"/opt/homebrew/bin/"
+    # Windows
+    elif system_name == "Windows":
+        EXEC_PATH = r"C:\Users\XXYYZZ"
+    else:
+        EXEC_PATH = r"/usr/bin"
 elif CROSS_TOOL == 'keil':
     PLATFORM    = 'armcc'
     EXEC_PATH   = r'C:/Keil_v5'
@@ -73,7 +85,7 @@ elif PLATFORM == 'armcc':
     DEVICE = ' --cpu Cortex-M4.fp '
     CFLAGS = '-c ' + DEVICE + ' --apcs=interwork --c99'
     AFLAGS = DEVICE + ' --apcs=interwork '
-    LFLAGS = DEVICE + ' --scatter "board\linker_scripts\link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
+    LFLAGS = DEVICE + ' --scatter "board/linker_scripts/link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
     CFLAGS += ' -I' + EXEC_PATH + '/ARM/ARMCC/include'
     LFLAGS += ' --libpath=' + EXEC_PATH + '/ARM/ARMCC/lib'
 
@@ -121,7 +133,6 @@ elif PLATFORM == 'armclang':
         AFLAGS += ' -g'
     else:
         CFLAGS += ' -O2'
-        
     CXXFLAGS = CFLAGS
     CFLAGS += ' -std=c99'
 
@@ -172,7 +183,6 @@ elif PLATFORM == 'iccarm':
     LFLAGS += ' --entry __iar_program_start'
 
     CXXFLAGS = CFLAGS
-    
     EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool --bin $TARGET rtthread.bin'
 

--- a/projects/03_driver_can/rtconfig.py
+++ b/projects/03_driver_can/rtconfig.py
@@ -1,5 +1,7 @@
 import os
+import platform
 
+system_name = platform.system()
 # toolchains options
 ARCH='arm'
 CPU='cortex-m4'
@@ -15,9 +17,19 @@ if os.getenv('RTT_ROOT'):
 
 # cross_tool provides the cross compiler
 # EXEC_PATH is the compiler execute path, for example, CodeSourcery, Keil MDK, IAR
-if  CROSS_TOOL == 'gcc':
-    PLATFORM    = 'gcc'
-    EXEC_PATH   = r'C:\Users\XXYYZZ'
+if CROSS_TOOL == "gcc":
+    PLATFORM = "gcc"
+    # Linux
+    if system_name == "Linux":
+        EXEC_PATH = r"/usr/bin"
+    # Macos
+    elif system_name == "Darwin":
+        EXEC_PATH = r"/opt/homebrew/bin/"
+    # Windows
+    elif system_name == "Windows":
+        EXEC_PATH = r"C:\Users\XXYYZZ"
+    else:
+        EXEC_PATH = r"/usr/bin"
 elif CROSS_TOOL == 'keil':
     PLATFORM    = 'armcc'
     EXEC_PATH   = r'C:/Keil_v5'
@@ -73,7 +85,7 @@ elif PLATFORM == 'armcc':
     DEVICE = ' --cpu Cortex-M4.fp '
     CFLAGS = '-c ' + DEVICE + ' --apcs=interwork --c99'
     AFLAGS = DEVICE + ' --apcs=interwork '
-    LFLAGS = DEVICE + ' --scatter "board\linker_scripts\link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
+    LFLAGS = DEVICE + ' --scatter "board/linker_scripts/link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
     CFLAGS += ' -I' + EXEC_PATH + '/ARM/ARMCC/include'
     LFLAGS += ' --libpath=' + EXEC_PATH + '/ARM/ARMCC/lib'
 
@@ -121,7 +133,6 @@ elif PLATFORM == 'armclang':
         AFLAGS += ' -g'
     else:
         CFLAGS += ' -O2'
-        
     CXXFLAGS = CFLAGS
     CFLAGS += ' -std=c99'
 
@@ -172,7 +183,6 @@ elif PLATFORM == 'iccarm':
     LFLAGS += ' --entry __iar_program_start'
 
     CXXFLAGS = CFLAGS
-    
     EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool --bin $TARGET rtthread.bin'
 

--- a/projects/03_driver_lcd/rtconfig.py
+++ b/projects/03_driver_lcd/rtconfig.py
@@ -1,5 +1,7 @@
 import os
+import platform
 
+system_name = platform.system()
 # toolchains options
 ARCH='arm'
 CPU='cortex-m4'
@@ -15,9 +17,19 @@ if os.getenv('RTT_ROOT'):
 
 # cross_tool provides the cross compiler
 # EXEC_PATH is the compiler execute path, for example, CodeSourcery, Keil MDK, IAR
-if  CROSS_TOOL == 'gcc':
-    PLATFORM    = 'gcc'
-    EXEC_PATH   = r'C:\Users\XXYYZZ'
+if CROSS_TOOL == "gcc":
+    PLATFORM = "gcc"
+    # Linux
+    if system_name == "Linux":
+        EXEC_PATH = r"/usr/bin"
+    # Macos
+    elif system_name == "Darwin":
+        EXEC_PATH = r"/opt/homebrew/bin/"
+    # Windows
+    elif system_name == "Windows":
+        EXEC_PATH = r"C:\Users\XXYYZZ"
+    else:
+        EXEC_PATH = r"/usr/bin"
 elif CROSS_TOOL == 'keil':
     PLATFORM    = 'armcc'
     EXEC_PATH   = r'C:/Keil_v5'
@@ -73,7 +85,7 @@ elif PLATFORM == 'armcc':
     DEVICE = ' --cpu Cortex-M4.fp '
     CFLAGS = '-c ' + DEVICE + ' --apcs=interwork --c99'
     AFLAGS = DEVICE + ' --apcs=interwork '
-    LFLAGS = DEVICE + ' --scatter "board\linker_scripts\link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
+    LFLAGS = DEVICE + ' --scatter "board/linker_scripts/link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
     CFLAGS += ' -I' + EXEC_PATH + '/ARM/ARMCC/include'
     LFLAGS += ' --libpath=' + EXEC_PATH + '/ARM/ARMCC/lib'
 
@@ -121,7 +133,6 @@ elif PLATFORM == 'armclang':
         AFLAGS += ' -g'
     else:
         CFLAGS += ' -O2'
-        
     CXXFLAGS = CFLAGS
     CFLAGS += ' -std=c99'
 
@@ -172,7 +183,6 @@ elif PLATFORM == 'iccarm':
     LFLAGS += ' --entry __iar_program_start'
 
     CXXFLAGS = CFLAGS
-    
     EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool --bin $TARGET rtthread.bin'
 

--- a/projects/03_driver_led_matrix/rtconfig.py
+++ b/projects/03_driver_led_matrix/rtconfig.py
@@ -1,5 +1,7 @@
 import os
+import platform
 
+system_name = platform.system()
 # toolchains options
 ARCH='arm'
 CPU='cortex-m4'
@@ -15,9 +17,19 @@ if os.getenv('RTT_ROOT'):
 
 # cross_tool provides the cross compiler
 # EXEC_PATH is the compiler execute path, for example, CodeSourcery, Keil MDK, IAR
-if  CROSS_TOOL == 'gcc':
-    PLATFORM    = 'gcc'
-    EXEC_PATH   = r'C:\Users\XXYYZZ'
+if CROSS_TOOL == "gcc":
+    PLATFORM = "gcc"
+    # Linux
+    if system_name == "Linux":
+        EXEC_PATH = r"/usr/bin"
+    # Macos
+    elif system_name == "Darwin":
+        EXEC_PATH = r"/opt/homebrew/bin/"
+    # Windows
+    elif system_name == "Windows":
+        EXEC_PATH = r"C:\Users\XXYYZZ"
+    else:
+        EXEC_PATH = r"/usr/bin"
 elif CROSS_TOOL == 'keil':
     PLATFORM    = 'armcc'
     EXEC_PATH   = r'C:/Keil_v5'
@@ -73,7 +85,7 @@ elif PLATFORM == 'armcc':
     DEVICE = ' --cpu Cortex-M4.fp '
     CFLAGS = '-c ' + DEVICE + ' --apcs=interwork --c99'
     AFLAGS = DEVICE + ' --apcs=interwork '
-    LFLAGS = DEVICE + ' --scatter "board\linker_scripts\link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
+    LFLAGS = DEVICE + ' --scatter "board/linker_scripts/link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
     CFLAGS += ' -I' + EXEC_PATH + '/ARM/ARMCC/include'
     LFLAGS += ' --libpath=' + EXEC_PATH + '/ARM/ARMCC/lib'
 
@@ -121,7 +133,6 @@ elif PLATFORM == 'armclang':
         AFLAGS += ' -g'
     else:
         CFLAGS += ' -O2'
-        
     CXXFLAGS = CFLAGS
     CFLAGS += ' -std=c99'
 
@@ -172,7 +183,6 @@ elif PLATFORM == 'iccarm':
     LFLAGS += ' --entry __iar_program_start'
 
     CXXFLAGS = CFLAGS
-    
     EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool --bin $TARGET rtthread.bin'
 

--- a/projects/03_driver_temp_humi/rtconfig.py
+++ b/projects/03_driver_temp_humi/rtconfig.py
@@ -1,5 +1,7 @@
 import os
+import platform
 
+system_name = platform.system()
 # toolchains options
 ARCH='arm'
 CPU='cortex-m4'
@@ -15,9 +17,19 @@ if os.getenv('RTT_ROOT'):
 
 # cross_tool provides the cross compiler
 # EXEC_PATH is the compiler execute path, for example, CodeSourcery, Keil MDK, IAR
-if  CROSS_TOOL == 'gcc':
-    PLATFORM    = 'gcc'
-    EXEC_PATH   = r'C:\Users\XXYYZZ'
+if CROSS_TOOL == "gcc":
+    PLATFORM = "gcc"
+    # Linux
+    if system_name == "Linux":
+        EXEC_PATH = r"/usr/bin"
+    # Macos
+    elif system_name == "Darwin":
+        EXEC_PATH = r"/opt/homebrew/bin/"
+    # Windows
+    elif system_name == "Windows":
+        EXEC_PATH = r"C:\Users\XXYYZZ"
+    else:
+        EXEC_PATH = r"/usr/bin"
 elif CROSS_TOOL == 'keil':
     PLATFORM    = 'armcc'
     EXEC_PATH   = r'C:/Keil_v5'
@@ -73,7 +85,7 @@ elif PLATFORM == 'armcc':
     DEVICE = ' --cpu Cortex-M4.fp '
     CFLAGS = '-c ' + DEVICE + ' --apcs=interwork --c99'
     AFLAGS = DEVICE + ' --apcs=interwork '
-    LFLAGS = DEVICE + ' --scatter "board\linker_scripts\link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
+    LFLAGS = DEVICE + ' --scatter "board/linker_scripts/link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
     CFLAGS += ' -I' + EXEC_PATH + '/ARM/ARMCC/include'
     LFLAGS += ' --libpath=' + EXEC_PATH + '/ARM/ARMCC/lib'
 
@@ -121,7 +133,6 @@ elif PLATFORM == 'armclang':
         AFLAGS += ' -g'
     else:
         CFLAGS += ' -O2'
-        
     CXXFLAGS = CFLAGS
     CFLAGS += ' -std=c99'
 
@@ -172,7 +183,6 @@ elif PLATFORM == 'iccarm':
     LFLAGS += ' --entry __iar_program_start'
 
     CXXFLAGS = CFLAGS
-    
     EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool --bin $TARGET rtthread.bin'
 

--- a/projects/04_component_fal/rtconfig.py
+++ b/projects/04_component_fal/rtconfig.py
@@ -1,5 +1,7 @@
 import os
+import platform
 
+system_name = platform.system()
 # toolchains options
 ARCH='arm'
 CPU='cortex-m4'
@@ -15,9 +17,19 @@ if os.getenv('RTT_ROOT'):
 
 # cross_tool provides the cross compiler
 # EXEC_PATH is the compiler execute path, for example, CodeSourcery, Keil MDK, IAR
-if  CROSS_TOOL == 'gcc':
-    PLATFORM    = 'gcc'
-    EXEC_PATH   = r'C:\Users\XXYYZZ'
+if CROSS_TOOL == "gcc":
+    PLATFORM = "gcc"
+    # Linux
+    if system_name == "Linux":
+        EXEC_PATH = r"/usr/bin"
+    # Macos
+    elif system_name == "Darwin":
+        EXEC_PATH = r"/opt/homebrew/bin/"
+    # Windows
+    elif system_name == "Windows":
+        EXEC_PATH = r"C:\Users\XXYYZZ"
+    else:
+        EXEC_PATH = r"/usr/bin"
 elif CROSS_TOOL == 'keil':
     PLATFORM    = 'armcc'
     EXEC_PATH   = r'C:/Keil_v5'
@@ -73,7 +85,7 @@ elif PLATFORM == 'armcc':
     DEVICE = ' --cpu Cortex-M4.fp '
     CFLAGS = '-c ' + DEVICE + ' --apcs=interwork --c99'
     AFLAGS = DEVICE + ' --apcs=interwork '
-    LFLAGS = DEVICE + ' --scatter "board\linker_scripts\link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
+    LFLAGS = DEVICE + ' --scatter "board/linker_scripts/link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
     CFLAGS += ' -I' + EXEC_PATH + '/ARM/ARMCC/include'
     LFLAGS += ' --libpath=' + EXEC_PATH + '/ARM/ARMCC/lib'
 
@@ -121,7 +133,6 @@ elif PLATFORM == 'armclang':
         AFLAGS += ' -g'
     else:
         CFLAGS += ' -O2'
-        
     CXXFLAGS = CFLAGS
     CFLAGS += ' -std=c99'
 
@@ -172,7 +183,6 @@ elif PLATFORM == 'iccarm':
     LFLAGS += ' --entry __iar_program_start'
 
     CXXFLAGS = CFLAGS
-    
     EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool --bin $TARGET rtthread.bin'
 

--- a/projects/04_component_fs_flash/rtconfig.py
+++ b/projects/04_component_fs_flash/rtconfig.py
@@ -1,5 +1,7 @@
 import os
+import platform
 
+system_name = platform.system()
 # toolchains options
 ARCH='arm'
 CPU='cortex-m4'
@@ -15,9 +17,19 @@ if os.getenv('RTT_ROOT'):
 
 # cross_tool provides the cross compiler
 # EXEC_PATH is the compiler execute path, for example, CodeSourcery, Keil MDK, IAR
-if  CROSS_TOOL == 'gcc':
-    PLATFORM    = 'gcc'
-    EXEC_PATH   = r'C:\Users\XXYYZZ'
+if CROSS_TOOL == "gcc":
+    PLATFORM = "gcc"
+    # Linux
+    if system_name == "Linux":
+        EXEC_PATH = r"/usr/bin"
+    # Macos
+    elif system_name == "Darwin":
+        EXEC_PATH = r"/opt/homebrew/bin/"
+    # Windows
+    elif system_name == "Windows":
+        EXEC_PATH = r"C:\Users\XXYYZZ"
+    else:
+        EXEC_PATH = r"/usr/bin"
 elif CROSS_TOOL == 'keil':
     PLATFORM    = 'armcc'
     EXEC_PATH   = r'C:/Keil_v5'
@@ -73,7 +85,7 @@ elif PLATFORM == 'armcc':
     DEVICE = ' --cpu Cortex-M4.fp '
     CFLAGS = '-c ' + DEVICE + ' --apcs=interwork --c99'
     AFLAGS = DEVICE + ' --apcs=interwork '
-    LFLAGS = DEVICE + ' --scatter "board\linker_scripts\link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
+    LFLAGS = DEVICE + ' --scatter "board/linker_scripts/link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
     CFLAGS += ' -I' + EXEC_PATH + '/ARM/ARMCC/include'
     LFLAGS += ' --libpath=' + EXEC_PATH + '/ARM/ARMCC/lib'
 
@@ -121,7 +133,6 @@ elif PLATFORM == 'armclang':
         AFLAGS += ' -g'
     else:
         CFLAGS += ' -O2'
-        
     CXXFLAGS = CFLAGS
     CFLAGS += ' -std=c99'
 
@@ -172,7 +183,6 @@ elif PLATFORM == 'iccarm':
     LFLAGS += ' --entry __iar_program_start'
 
     CXXFLAGS = CFLAGS
-    
     EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool --bin $TARGET rtthread.bin'
 

--- a/projects/04_component_fs_tf_card/rtconfig.py
+++ b/projects/04_component_fs_tf_card/rtconfig.py
@@ -1,5 +1,7 @@
 import os
+import platform
 
+system_name = platform.system()
 # toolchains options
 ARCH='arm'
 CPU='cortex-m4'
@@ -15,9 +17,19 @@ if os.getenv('RTT_ROOT'):
 
 # cross_tool provides the cross compiler
 # EXEC_PATH is the compiler execute path, for example, CodeSourcery, Keil MDK, IAR
-if  CROSS_TOOL == 'gcc':
-    PLATFORM    = 'gcc'
-    EXEC_PATH   = r'C:\Users\XXYYZZ'
+if CROSS_TOOL == "gcc":
+    PLATFORM = "gcc"
+    # Linux
+    if system_name == "Linux":
+        EXEC_PATH = r"/usr/bin"
+    # Macos
+    elif system_name == "Darwin":
+        EXEC_PATH = r"/opt/homebrew/bin/"
+    # Windows
+    elif system_name == "Windows":
+        EXEC_PATH = r"C:\Users\XXYYZZ"
+    else:
+        EXEC_PATH = r"/usr/bin"
 elif CROSS_TOOL == 'keil':
     PLATFORM    = 'armcc'
     EXEC_PATH   = r'C:/Keil_v5'
@@ -73,7 +85,7 @@ elif PLATFORM == 'armcc':
     DEVICE = ' --cpu Cortex-M4.fp '
     CFLAGS = '-c ' + DEVICE + ' --apcs=interwork --c99'
     AFLAGS = DEVICE + ' --apcs=interwork '
-    LFLAGS = DEVICE + ' --scatter "board\linker_scripts\link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
+    LFLAGS = DEVICE + ' --scatter "board/linker_scripts/link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
     CFLAGS += ' -I' + EXEC_PATH + '/ARM/ARMCC/include'
     LFLAGS += ' --libpath=' + EXEC_PATH + '/ARM/ARMCC/lib'
 
@@ -121,7 +133,6 @@ elif PLATFORM == 'armclang':
         AFLAGS += ' -g'
     else:
         CFLAGS += ' -O2'
-        
     CXXFLAGS = CFLAGS
     CFLAGS += ' -std=c99'
 
@@ -172,7 +183,6 @@ elif PLATFORM == 'iccarm':
     LFLAGS += ' --entry __iar_program_start'
 
     CXXFLAGS = CFLAGS
-    
     EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool --bin $TARGET rtthread.bin'
 

--- a/projects/04_component_kv/rtconfig.py
+++ b/projects/04_component_kv/rtconfig.py
@@ -1,5 +1,7 @@
 import os
+import platform
 
+system_name = platform.system()
 # toolchains options
 ARCH='arm'
 CPU='cortex-m4'
@@ -15,9 +17,19 @@ if os.getenv('RTT_ROOT'):
 
 # cross_tool provides the cross compiler
 # EXEC_PATH is the compiler execute path, for example, CodeSourcery, Keil MDK, IAR
-if  CROSS_TOOL == 'gcc':
-    PLATFORM    = 'gcc'
-    EXEC_PATH   = r'C:\Users\XXYYZZ'
+if CROSS_TOOL == "gcc":
+    PLATFORM = "gcc"
+    # Linux
+    if system_name == "Linux":
+        EXEC_PATH = r"/usr/bin"
+    # Macos
+    elif system_name == "Darwin":
+        EXEC_PATH = r"/opt/homebrew/bin/"
+    # Windows
+    elif system_name == "Windows":
+        EXEC_PATH = r"C:\Users\XXYYZZ"
+    else:
+        EXEC_PATH = r"/usr/bin"
 elif CROSS_TOOL == 'keil':
     PLATFORM    = 'armcc'
     EXEC_PATH   = r'C:/Keil_v5'
@@ -73,7 +85,7 @@ elif PLATFORM == 'armcc':
     DEVICE = ' --cpu Cortex-M4.fp '
     CFLAGS = '-c ' + DEVICE + ' --apcs=interwork --c99'
     AFLAGS = DEVICE + ' --apcs=interwork '
-    LFLAGS = DEVICE + ' --scatter "board\linker_scripts\link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
+    LFLAGS = DEVICE + ' --scatter "board/linker_scripts/link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
     CFLAGS += ' -I' + EXEC_PATH + '/ARM/ARMCC/include'
     LFLAGS += ' --libpath=' + EXEC_PATH + '/ARM/ARMCC/lib'
 
@@ -121,7 +133,6 @@ elif PLATFORM == 'armclang':
         AFLAGS += ' -g'
     else:
         CFLAGS += ' -O2'
-        
     CXXFLAGS = CFLAGS
     CFLAGS += ' -std=c99'
 
@@ -172,7 +183,6 @@ elif PLATFORM == 'iccarm':
     LFLAGS += ' --entry __iar_program_start'
 
     CXXFLAGS = CFLAGS
-    
     EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool --bin $TARGET rtthread.bin'
 

--- a/projects/04_component_pm/rtconfig.py
+++ b/projects/04_component_pm/rtconfig.py
@@ -1,5 +1,7 @@
 import os
+import platform
 
+system_name = platform.system()
 # toolchains options
 ARCH='arm'
 CPU='cortex-m4'
@@ -15,9 +17,19 @@ if os.getenv('RTT_ROOT'):
 
 # cross_tool provides the cross compiler
 # EXEC_PATH is the compiler execute path, for example, CodeSourcery, Keil MDK, IAR
-if  CROSS_TOOL == 'gcc':
-    PLATFORM    = 'gcc'
-    EXEC_PATH   = r'C:\Users\XXYYZZ'
+if CROSS_TOOL == "gcc":
+    PLATFORM = "gcc"
+    # Linux
+    if system_name == "Linux":
+        EXEC_PATH = r"/usr/bin"
+    # Macos
+    elif system_name == "Darwin":
+        EXEC_PATH = r"/opt/homebrew/bin/"
+    # Windows
+    elif system_name == "Windows":
+        EXEC_PATH = r"C:\Users\XXYYZZ"
+    else:
+        EXEC_PATH = r"/usr/bin"
 elif CROSS_TOOL == 'keil':
     PLATFORM    = 'armcc'
     EXEC_PATH   = r'C:/Keil_v5'
@@ -73,7 +85,7 @@ elif PLATFORM == 'armcc':
     DEVICE = ' --cpu Cortex-M4.fp '
     CFLAGS = '-c ' + DEVICE + ' --apcs=interwork --c99'
     AFLAGS = DEVICE + ' --apcs=interwork '
-    LFLAGS = DEVICE + ' --scatter "board\linker_scripts\link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
+    LFLAGS = DEVICE + ' --scatter "board/linker_scripts/link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
     CFLAGS += ' -I' + EXEC_PATH + '/ARM/ARMCC/include'
     LFLAGS += ' --libpath=' + EXEC_PATH + '/ARM/ARMCC/lib'
 
@@ -121,7 +133,6 @@ elif PLATFORM == 'armclang':
         AFLAGS += ' -g'
     else:
         CFLAGS += ' -O2'
-        
     CXXFLAGS = CFLAGS
     CFLAGS += ' -std=c99'
 
@@ -172,7 +183,6 @@ elif PLATFORM == 'iccarm':
     LFLAGS += ' --entry __iar_program_start'
 
     CXXFLAGS = CFLAGS
-    
     EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool --bin $TARGET rtthread.bin'
 

--- a/projects/04_component_usb_mouse/rtconfig.py
+++ b/projects/04_component_usb_mouse/rtconfig.py
@@ -1,5 +1,7 @@
 import os
+import platform
 
+system_name = platform.system()
 # toolchains options
 ARCH='arm'
 CPU='cortex-m4'
@@ -15,9 +17,19 @@ if os.getenv('RTT_ROOT'):
 
 # cross_tool provides the cross compiler
 # EXEC_PATH is the compiler execute path, for example, CodeSourcery, Keil MDK, IAR
-if  CROSS_TOOL == 'gcc':
-    PLATFORM    = 'gcc'
-    EXEC_PATH   = r'C:\Users\XXYYZZ'
+if CROSS_TOOL == "gcc":
+    PLATFORM = "gcc"
+    # Linux
+    if system_name == "Linux":
+        EXEC_PATH = r"/usr/bin"
+    # Macos
+    elif system_name == "Darwin":
+        EXEC_PATH = r"/opt/homebrew/bin/"
+    # Windows
+    elif system_name == "Windows":
+        EXEC_PATH = r"C:\Users\XXYYZZ"
+    else:
+        EXEC_PATH = r"/usr/bin"
 elif CROSS_TOOL == 'keil':
     PLATFORM    = 'armcc'
     EXEC_PATH   = r'C:/Keil_v5'
@@ -73,7 +85,7 @@ elif PLATFORM == 'armcc':
     DEVICE = ' --cpu Cortex-M4.fp '
     CFLAGS = '-c ' + DEVICE + ' --apcs=interwork --c99'
     AFLAGS = DEVICE + ' --apcs=interwork '
-    LFLAGS = DEVICE + ' --scatter "board\linker_scripts\link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
+    LFLAGS = DEVICE + ' --scatter "board/linker_scripts/link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
     CFLAGS += ' -I' + EXEC_PATH + '/ARM/ARMCC/include'
     LFLAGS += ' --libpath=' + EXEC_PATH + '/ARM/ARMCC/lib'
 
@@ -121,7 +133,6 @@ elif PLATFORM == 'armclang':
         AFLAGS += ' -g'
     else:
         CFLAGS += ' -O2'
-        
     CXXFLAGS = CFLAGS
     CFLAGS += ' -std=c99'
 
@@ -172,7 +183,6 @@ elif PLATFORM == 'iccarm':
     LFLAGS += ' --entry __iar_program_start'
 
     CXXFLAGS = CFLAGS
-    
     EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool --bin $TARGET rtthread.bin'
 

--- a/projects/05_iot_cloud_ali_iotkit/rtconfig.py
+++ b/projects/05_iot_cloud_ali_iotkit/rtconfig.py
@@ -1,5 +1,7 @@
 import os
+import platform
 
+system_name = platform.system()
 # toolchains options
 ARCH='arm'
 CPU='cortex-m4'
@@ -15,9 +17,19 @@ if os.getenv('RTT_ROOT'):
 
 # cross_tool provides the cross compiler
 # EXEC_PATH is the compiler execute path, for example, CodeSourcery, Keil MDK, IAR
-if  CROSS_TOOL == 'gcc':
-    PLATFORM    = 'gcc'
-    EXEC_PATH   = r'C:\Users\XXYYZZ'
+if CROSS_TOOL == "gcc":
+    PLATFORM = "gcc"
+    # Linux
+    if system_name == "Linux":
+        EXEC_PATH = r"/usr/bin"
+    # Macos
+    elif system_name == "Darwin":
+        EXEC_PATH = r"/opt/homebrew/bin/"
+    # Windows
+    elif system_name == "Windows":
+        EXEC_PATH = r"C:\Users\XXYYZZ"
+    else:
+        EXEC_PATH = r"/usr/bin"
 elif CROSS_TOOL == 'keil':
     PLATFORM    = 'armcc'
     EXEC_PATH   = r'C:/Keil_v5'
@@ -73,7 +85,7 @@ elif PLATFORM == 'armcc':
     DEVICE = ' --cpu Cortex-M4.fp '
     CFLAGS = '-c ' + DEVICE + ' --apcs=interwork --c99'
     AFLAGS = DEVICE + ' --apcs=interwork '
-    LFLAGS = DEVICE + ' --scatter "board\linker_scripts\link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
+    LFLAGS = DEVICE + ' --scatter "board/linker_scripts/link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
     CFLAGS += ' -I' + EXEC_PATH + '/ARM/ARMCC/include'
     LFLAGS += ' --libpath=' + EXEC_PATH + '/ARM/ARMCC/lib'
 
@@ -121,7 +133,6 @@ elif PLATFORM == 'armclang':
         AFLAGS += ' -g'
     else:
         CFLAGS += ' -O2'
-        
     CXXFLAGS = CFLAGS
     CFLAGS += ' -std=c99'
 
@@ -172,7 +183,6 @@ elif PLATFORM == 'iccarm':
     LFLAGS += ' --entry __iar_program_start'
 
     CXXFLAGS = CFLAGS
-    
     EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool --bin $TARGET rtthread.bin'
 

--- a/projects/05_iot_cloud_onenet/rtconfig.py
+++ b/projects/05_iot_cloud_onenet/rtconfig.py
@@ -1,5 +1,7 @@
 import os
+import platform
 
+system_name = platform.system()
 # toolchains options
 ARCH='arm'
 CPU='cortex-m4'
@@ -15,9 +17,19 @@ if os.getenv('RTT_ROOT'):
 
 # cross_tool provides the cross compiler
 # EXEC_PATH is the compiler execute path, for example, CodeSourcery, Keil MDK, IAR
-if  CROSS_TOOL == 'gcc':
-    PLATFORM    = 'gcc'
-    EXEC_PATH   = r'C:\Users\XXYYZZ'
+if CROSS_TOOL == "gcc":
+    PLATFORM = "gcc"
+    # Linux
+    if system_name == "Linux":
+        EXEC_PATH = r"/usr/bin"
+    # Macos
+    elif system_name == "Darwin":
+        EXEC_PATH = r"/opt/homebrew/bin/"
+    # Windows
+    elif system_name == "Windows":
+        EXEC_PATH = r"C:\Users\XXYYZZ"
+    else:
+        EXEC_PATH = r"/usr/bin"
 elif CROSS_TOOL == 'keil':
     PLATFORM    = 'armcc'
     EXEC_PATH   = r'C:/Keil_v5'
@@ -73,7 +85,7 @@ elif PLATFORM == 'armcc':
     DEVICE = ' --cpu Cortex-M4.fp '
     CFLAGS = '-c ' + DEVICE + ' --apcs=interwork --c99'
     AFLAGS = DEVICE + ' --apcs=interwork '
-    LFLAGS = DEVICE + ' --scatter "board\linker_scripts\link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
+    LFLAGS = DEVICE + ' --scatter "board/linker_scripts/link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
     CFLAGS += ' -I' + EXEC_PATH + '/ARM/ARMCC/include'
     LFLAGS += ' --libpath=' + EXEC_PATH + '/ARM/ARMCC/lib'
 
@@ -121,7 +133,6 @@ elif PLATFORM == 'armclang':
         AFLAGS += ' -g'
     else:
         CFLAGS += ' -O2'
-        
     CXXFLAGS = CFLAGS
     CFLAGS += ' -std=c99'
 
@@ -172,7 +183,6 @@ elif PLATFORM == 'iccarm':
     LFLAGS += ' --entry __iar_program_start'
 
     CXXFLAGS = CFLAGS
-    
     EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool --bin $TARGET rtthread.bin'
 

--- a/projects/05_iot_http_client/rtconfig.py
+++ b/projects/05_iot_http_client/rtconfig.py
@@ -1,5 +1,7 @@
 import os
+import platform
 
+system_name = platform.system()
 # toolchains options
 ARCH='arm'
 CPU='cortex-m4'
@@ -15,9 +17,19 @@ if os.getenv('RTT_ROOT'):
 
 # cross_tool provides the cross compiler
 # EXEC_PATH is the compiler execute path, for example, CodeSourcery, Keil MDK, IAR
-if  CROSS_TOOL == 'gcc':
-    PLATFORM    = 'gcc'
-    EXEC_PATH   = r'C:\Users\XXYYZZ'
+if CROSS_TOOL == "gcc":
+    PLATFORM = "gcc"
+    # Linux
+    if system_name == "Linux":
+        EXEC_PATH = r"/usr/bin"
+    # Macos
+    elif system_name == "Darwin":
+        EXEC_PATH = r"/opt/homebrew/bin/"
+    # Windows
+    elif system_name == "Windows":
+        EXEC_PATH = r"C:\Users\XXYYZZ"
+    else:
+        EXEC_PATH = r"/usr/bin"
 elif CROSS_TOOL == 'keil':
     PLATFORM    = 'armcc'
     EXEC_PATH   = r'C:/Keil_v5'
@@ -73,7 +85,7 @@ elif PLATFORM == 'armcc':
     DEVICE = ' --cpu Cortex-M4.fp '
     CFLAGS = '-c ' + DEVICE + ' --apcs=interwork --c99'
     AFLAGS = DEVICE + ' --apcs=interwork '
-    LFLAGS = DEVICE + ' --scatter "board\linker_scripts\link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
+    LFLAGS = DEVICE + ' --scatter "board/linker_scripts/link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
     CFLAGS += ' -I' + EXEC_PATH + '/ARM/ARMCC/include'
     LFLAGS += ' --libpath=' + EXEC_PATH + '/ARM/ARMCC/lib'
 
@@ -121,7 +133,6 @@ elif PLATFORM == 'armclang':
         AFLAGS += ' -g'
     else:
         CFLAGS += ' -O2'
-        
     CXXFLAGS = CFLAGS
     CFLAGS += ' -std=c99'
 
@@ -172,7 +183,6 @@ elif PLATFORM == 'iccarm':
     LFLAGS += ' --entry __iar_program_start'
 
     CXXFLAGS = CFLAGS
-    
     EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool --bin $TARGET rtthread.bin'
 

--- a/projects/05_iot_mbedtls/rtconfig.py
+++ b/projects/05_iot_mbedtls/rtconfig.py
@@ -1,5 +1,7 @@
 import os
+import platform
 
+system_name = platform.system()
 # toolchains options
 ARCH='arm'
 CPU='cortex-m4'
@@ -15,9 +17,19 @@ if os.getenv('RTT_ROOT'):
 
 # cross_tool provides the cross compiler
 # EXEC_PATH is the compiler execute path, for example, CodeSourcery, Keil MDK, IAR
-if  CROSS_TOOL == 'gcc':
-    PLATFORM    = 'gcc'
-    EXEC_PATH   = r'C:\Users\XXYYZZ'
+if CROSS_TOOL == "gcc":
+    PLATFORM = "gcc"
+    # Linux
+    if system_name == "Linux":
+        EXEC_PATH = r"/usr/bin"
+    # Macos
+    elif system_name == "Darwin":
+        EXEC_PATH = r"/opt/homebrew/bin/"
+    # Windows
+    elif system_name == "Windows":
+        EXEC_PATH = r"C:\Users\XXYYZZ"
+    else:
+        EXEC_PATH = r"/usr/bin"
 elif CROSS_TOOL == 'keil':
     PLATFORM    = 'armcc'
     EXEC_PATH   = r'C:/Keil_v5'
@@ -73,7 +85,7 @@ elif PLATFORM == 'armcc':
     DEVICE = ' --cpu Cortex-M4.fp '
     CFLAGS = '-c ' + DEVICE + ' --apcs=interwork --c99'
     AFLAGS = DEVICE + ' --apcs=interwork '
-    LFLAGS = DEVICE + ' --scatter "board\linker_scripts\link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
+    LFLAGS = DEVICE + ' --scatter "board/linker_scripts/link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
     CFLAGS += ' -I' + EXEC_PATH + '/ARM/ARMCC/include'
     LFLAGS += ' --libpath=' + EXEC_PATH + '/ARM/ARMCC/lib'
 
@@ -121,7 +133,6 @@ elif PLATFORM == 'armclang':
         AFLAGS += ' -g'
     else:
         CFLAGS += ' -O2'
-        
     CXXFLAGS = CFLAGS
     CFLAGS += ' -std=c99'
 
@@ -172,7 +183,6 @@ elif PLATFORM == 'iccarm':
     LFLAGS += ' --entry __iar_program_start'
 
     CXXFLAGS = CFLAGS
-    
     EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool --bin $TARGET rtthread.bin'
 

--- a/projects/05_iot_mqtt/rtconfig.py
+++ b/projects/05_iot_mqtt/rtconfig.py
@@ -1,5 +1,7 @@
 import os
+import platform
 
+system_name = platform.system()
 # toolchains options
 ARCH='arm'
 CPU='cortex-m4'
@@ -15,9 +17,19 @@ if os.getenv('RTT_ROOT'):
 
 # cross_tool provides the cross compiler
 # EXEC_PATH is the compiler execute path, for example, CodeSourcery, Keil MDK, IAR
-if  CROSS_TOOL == 'gcc':
-    PLATFORM    = 'gcc'
-    EXEC_PATH   = r'C:\Users\XXYYZZ'
+if CROSS_TOOL == "gcc":
+    PLATFORM = "gcc"
+    # Linux
+    if system_name == "Linux":
+        EXEC_PATH = r"/usr/bin"
+    # Macos
+    elif system_name == "Darwin":
+        EXEC_PATH = r"/opt/homebrew/bin/"
+    # Windows
+    elif system_name == "Windows":
+        EXEC_PATH = r"C:\Users\XXYYZZ"
+    else:
+        EXEC_PATH = r"/usr/bin"
 elif CROSS_TOOL == 'keil':
     PLATFORM    = 'armcc'
     EXEC_PATH   = r'C:/Keil_v5'
@@ -73,7 +85,7 @@ elif PLATFORM == 'armcc':
     DEVICE = ' --cpu Cortex-M4.fp '
     CFLAGS = '-c ' + DEVICE + ' --apcs=interwork --c99'
     AFLAGS = DEVICE + ' --apcs=interwork '
-    LFLAGS = DEVICE + ' --scatter "board\linker_scripts\link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
+    LFLAGS = DEVICE + ' --scatter "board/linker_scripts/link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
     CFLAGS += ' -I' + EXEC_PATH + '/ARM/ARMCC/include'
     LFLAGS += ' --libpath=' + EXEC_PATH + '/ARM/ARMCC/lib'
 
@@ -121,7 +133,6 @@ elif PLATFORM == 'armclang':
         AFLAGS += ' -g'
     else:
         CFLAGS += ' -O2'
-        
     CXXFLAGS = CFLAGS
     CFLAGS += ' -std=c99'
 
@@ -172,7 +183,6 @@ elif PLATFORM == 'iccarm':
     LFLAGS += ' --entry __iar_program_start'
 
     CXXFLAGS = CFLAGS
-    
     EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool --bin $TARGET rtthread.bin'
 

--- a/projects/05_iot_netutils/rtconfig.py
+++ b/projects/05_iot_netutils/rtconfig.py
@@ -1,5 +1,7 @@
 import os
+import platform
 
+system_name = platform.system()
 # toolchains options
 ARCH='arm'
 CPU='cortex-m4'
@@ -15,9 +17,19 @@ if os.getenv('RTT_ROOT'):
 
 # cross_tool provides the cross compiler
 # EXEC_PATH is the compiler execute path, for example, CodeSourcery, Keil MDK, IAR
-if  CROSS_TOOL == 'gcc':
-    PLATFORM    = 'gcc'
-    EXEC_PATH   = r'C:\Users\XXYYZZ'
+if CROSS_TOOL == "gcc":
+    PLATFORM = "gcc"
+    # Linux
+    if system_name == "Linux":
+        EXEC_PATH = r"/usr/bin"
+    # Macos
+    elif system_name == "Darwin":
+        EXEC_PATH = r"/opt/homebrew/bin/"
+    # Windows
+    elif system_name == "Windows":
+        EXEC_PATH = r"C:\Users\XXYYZZ"
+    else:
+        EXEC_PATH = r"/usr/bin"
 elif CROSS_TOOL == 'keil':
     PLATFORM    = 'armcc'
     EXEC_PATH   = r'C:/Keil_v5'
@@ -73,7 +85,7 @@ elif PLATFORM == 'armcc':
     DEVICE = ' --cpu Cortex-M4.fp '
     CFLAGS = '-c ' + DEVICE + ' --apcs=interwork --c99'
     AFLAGS = DEVICE + ' --apcs=interwork '
-    LFLAGS = DEVICE + ' --scatter "board\linker_scripts\link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
+    LFLAGS = DEVICE + ' --scatter "board/linker_scripts/link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
     CFLAGS += ' -I' + EXEC_PATH + '/ARM/ARMCC/include'
     LFLAGS += ' --libpath=' + EXEC_PATH + '/ARM/ARMCC/lib'
 
@@ -121,7 +133,6 @@ elif PLATFORM == 'armclang':
         AFLAGS += ' -g'
     else:
         CFLAGS += ' -O2'
-        
     CXXFLAGS = CFLAGS
     CFLAGS += ' -std=c99'
 
@@ -172,7 +183,6 @@ elif PLATFORM == 'iccarm':
     LFLAGS += ' --entry __iar_program_start'
 
     CXXFLAGS = CFLAGS
-    
     EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool --bin $TARGET rtthread.bin'
 

--- a/projects/05_iot_ota_http/rtconfig.py
+++ b/projects/05_iot_ota_http/rtconfig.py
@@ -1,5 +1,7 @@
 import os
+import platform
 
+system_name = platform.system()
 # toolchains options
 ARCH='arm'
 CPU='cortex-m4'
@@ -15,9 +17,19 @@ if os.getenv('RTT_ROOT'):
 
 # cross_tool provides the cross compiler
 # EXEC_PATH is the compiler execute path, for example, CodeSourcery, Keil MDK, IAR
-if  CROSS_TOOL == 'gcc':
-    PLATFORM    = 'gcc'
-    EXEC_PATH   = r'C:\Users\XXYYZZ'
+if CROSS_TOOL == "gcc":
+    PLATFORM = "gcc"
+    # Linux
+    if system_name == "Linux":
+        EXEC_PATH = r"/usr/bin"
+    # Macos
+    elif system_name == "Darwin":
+        EXEC_PATH = r"/opt/homebrew/bin/"
+    # Windows
+    elif system_name == "Windows":
+        EXEC_PATH = r"C:\Users\XXYYZZ"
+    else:
+        EXEC_PATH = r"/usr/bin"
 elif CROSS_TOOL == 'keil':
     PLATFORM    = 'armcc'
     EXEC_PATH   = r'C:/Keil_v5'
@@ -73,7 +85,7 @@ elif PLATFORM == 'armcc':
     DEVICE = ' --cpu Cortex-M4.fp '
     CFLAGS = '-c ' + DEVICE + ' --apcs=interwork --c99'
     AFLAGS = DEVICE + ' --apcs=interwork '
-    LFLAGS = DEVICE + ' --scatter "board\linker_scripts\link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
+    LFLAGS = DEVICE + ' --scatter "board/linker_scripts/link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
     CFLAGS += ' -I' + EXEC_PATH + '/ARM/ARMCC/include'
     LFLAGS += ' --libpath=' + EXEC_PATH + '/ARM/ARMCC/lib'
 
@@ -121,7 +133,6 @@ elif PLATFORM == 'armclang':
         AFLAGS += ' -g'
     else:
         CFLAGS += ' -O2'
-        
     CXXFLAGS = CFLAGS
     CFLAGS += ' -std=c99'
 
@@ -172,7 +183,6 @@ elif PLATFORM == 'iccarm':
     LFLAGS += ' --entry __iar_program_start'
 
     CXXFLAGS = CFLAGS
-    
     EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool --bin $TARGET rtthread.bin'
 

--- a/projects/05_iot_ota_ymodem/rtconfig.py
+++ b/projects/05_iot_ota_ymodem/rtconfig.py
@@ -1,5 +1,7 @@
 import os
+import platform
 
+system_name = platform.system()
 # toolchains options
 ARCH='arm'
 CPU='cortex-m4'
@@ -15,9 +17,19 @@ if os.getenv('RTT_ROOT'):
 
 # cross_tool provides the cross compiler
 # EXEC_PATH is the compiler execute path, for example, CodeSourcery, Keil MDK, IAR
-if  CROSS_TOOL == 'gcc':
-    PLATFORM    = 'gcc'
-    EXEC_PATH   = r'C:\Users\XXYYZZ'
+if CROSS_TOOL == "gcc":
+    PLATFORM = "gcc"
+    # Linux
+    if system_name == "Linux":
+        EXEC_PATH = r"/usr/bin"
+    # Macos
+    elif system_name == "Darwin":
+        EXEC_PATH = r"/opt/homebrew/bin/"
+    # Windows
+    elif system_name == "Windows":
+        EXEC_PATH = r"C:\Users\XXYYZZ"
+    else:
+        EXEC_PATH = r"/usr/bin"
 elif CROSS_TOOL == 'keil':
     PLATFORM    = 'armcc'
     EXEC_PATH   = r'C:/Keil_v5'
@@ -73,7 +85,7 @@ elif PLATFORM == 'armcc':
     DEVICE = ' --cpu Cortex-M4.fp '
     CFLAGS = '-c ' + DEVICE + ' --apcs=interwork --c99'
     AFLAGS = DEVICE + ' --apcs=interwork '
-    LFLAGS = DEVICE + ' --scatter "board\linker_scripts\link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
+    LFLAGS = DEVICE + ' --scatter "board/linker_scripts/link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
     CFLAGS += ' -I' + EXEC_PATH + '/ARM/ARMCC/include'
     LFLAGS += ' --libpath=' + EXEC_PATH + '/ARM/ARMCC/lib'
 
@@ -121,7 +133,6 @@ elif PLATFORM == 'armclang':
         AFLAGS += ' -g'
     else:
         CFLAGS += ' -O2'
-        
     CXXFLAGS = CFLAGS
     CFLAGS += ' -std=c99'
 
@@ -172,7 +183,6 @@ elif PLATFORM == 'iccarm':
     LFLAGS += ' --entry __iar_program_start'
 
     CXXFLAGS = CFLAGS
-    
     EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool --bin $TARGET rtthread.bin'
 

--- a/projects/05_iot_web_server/rtconfig.py
+++ b/projects/05_iot_web_server/rtconfig.py
@@ -1,5 +1,7 @@
 import os
+import platform
 
+system_name = platform.system()
 # toolchains options
 ARCH='arm'
 CPU='cortex-m4'
@@ -15,9 +17,19 @@ if os.getenv('RTT_ROOT'):
 
 # cross_tool provides the cross compiler
 # EXEC_PATH is the compiler execute path, for example, CodeSourcery, Keil MDK, IAR
-if  CROSS_TOOL == 'gcc':
-    PLATFORM    = 'gcc'
-    EXEC_PATH   = r'C:\Users\XXYYZZ'
+if CROSS_TOOL == "gcc":
+    PLATFORM = "gcc"
+    # Linux
+    if system_name == "Linux":
+        EXEC_PATH = r"/usr/bin"
+    # Macos
+    elif system_name == "Darwin":
+        EXEC_PATH = r"/opt/homebrew/bin/"
+    # Windows
+    elif system_name == "Windows":
+        EXEC_PATH = r"C:\Users\XXYYZZ"
+    else:
+        EXEC_PATH = r"/usr/bin"
 elif CROSS_TOOL == 'keil':
     PLATFORM    = 'armcc'
     EXEC_PATH   = r'C:/Keil_v5'
@@ -73,7 +85,7 @@ elif PLATFORM == 'armcc':
     DEVICE = ' --cpu Cortex-M4.fp '
     CFLAGS = '-c ' + DEVICE + ' --apcs=interwork --c99'
     AFLAGS = DEVICE + ' --apcs=interwork '
-    LFLAGS = DEVICE + ' --scatter "board\linker_scripts\link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
+    LFLAGS = DEVICE + ' --scatter "board/linker_scripts/link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
     CFLAGS += ' -I' + EXEC_PATH + '/ARM/ARMCC/include'
     LFLAGS += ' --libpath=' + EXEC_PATH + '/ARM/ARMCC/lib'
 
@@ -121,7 +133,6 @@ elif PLATFORM == 'armclang':
         AFLAGS += ' -g'
     else:
         CFLAGS += ' -O2'
-        
     CXXFLAGS = CFLAGS
     CFLAGS += ' -std=c99'
 
@@ -172,7 +183,6 @@ elif PLATFORM == 'iccarm':
     LFLAGS += ' --entry __iar_program_start'
 
     CXXFLAGS = CFLAGS
-    
     EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool --bin $TARGET rtthread.bin'
 

--- a/projects/05_iot_wifi_manager/rtconfig.py
+++ b/projects/05_iot_wifi_manager/rtconfig.py
@@ -1,5 +1,7 @@
 import os
+import platform
 
+system_name = platform.system()
 # toolchains options
 ARCH='arm'
 CPU='cortex-m4'
@@ -15,9 +17,19 @@ if os.getenv('RTT_ROOT'):
 
 # cross_tool provides the cross compiler
 # EXEC_PATH is the compiler execute path, for example, CodeSourcery, Keil MDK, IAR
-if  CROSS_TOOL == 'gcc':
-    PLATFORM    = 'gcc'
-    EXEC_PATH   = r'C:\Users\XXYYZZ'
+if CROSS_TOOL == "gcc":
+    PLATFORM = "gcc"
+    # Linux
+    if system_name == "Linux":
+        EXEC_PATH = r"/usr/bin"
+    # Macos
+    elif system_name == "Darwin":
+        EXEC_PATH = r"/opt/homebrew/bin/"
+    # Windows
+    elif system_name == "Windows":
+        EXEC_PATH = r"C:\Users\XXYYZZ"
+    else:
+        EXEC_PATH = r"/usr/bin"
 elif CROSS_TOOL == 'keil':
     PLATFORM    = 'armcc'
     EXEC_PATH   = r'C:/Keil_v5'
@@ -73,7 +85,7 @@ elif PLATFORM == 'armcc':
     DEVICE = ' --cpu Cortex-M4.fp '
     CFLAGS = '-c ' + DEVICE + ' --apcs=interwork --c99'
     AFLAGS = DEVICE + ' --apcs=interwork '
-    LFLAGS = DEVICE + ' --scatter "board\linker_scripts\link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
+    LFLAGS = DEVICE + ' --scatter "board/linker_scripts/link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
     CFLAGS += ' -I' + EXEC_PATH + '/ARM/ARMCC/include'
     LFLAGS += ' --libpath=' + EXEC_PATH + '/ARM/ARMCC/lib'
 
@@ -121,7 +133,6 @@ elif PLATFORM == 'armclang':
         AFLAGS += ' -g'
     else:
         CFLAGS += ' -O2'
-        
     CXXFLAGS = CFLAGS
     CFLAGS += ' -std=c99'
 
@@ -172,7 +183,6 @@ elif PLATFORM == 'iccarm':
     LFLAGS += ' --entry __iar_program_start'
 
     CXXFLAGS = CFLAGS
-    
     EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool --bin $TARGET rtthread.bin'
 

--- a/projects/06_demo_factory/rtconfig.py
+++ b/projects/06_demo_factory/rtconfig.py
@@ -1,5 +1,7 @@
 import os
+import platform
 
+system_name = platform.system()
 # toolchains options
 ARCH='arm'
 CPU='cortex-m4'
@@ -15,9 +17,19 @@ if os.getenv('RTT_ROOT'):
 
 # cross_tool provides the cross compiler
 # EXEC_PATH is the compiler execute path, for example, CodeSourcery, Keil MDK, IAR
-if  CROSS_TOOL == 'gcc':
-    PLATFORM    = 'gcc'
-    EXEC_PATH   = r'C:\Users\XXYYZZ'
+if CROSS_TOOL == "gcc":
+    PLATFORM = "gcc"
+    # Linux
+    if system_name == "Linux":
+        EXEC_PATH = r"/usr/bin"
+    # Macos
+    elif system_name == "Darwin":
+        EXEC_PATH = r"/opt/homebrew/bin/"
+    # Windows
+    elif system_name == "Windows":
+        EXEC_PATH = r"C:\Users\XXYYZZ"
+    else:
+        EXEC_PATH = r"/usr/bin"
 elif CROSS_TOOL == 'keil':
     PLATFORM    = 'armcc'
     EXEC_PATH   = r'C:/Keil_v5'
@@ -28,7 +40,7 @@ elif CROSS_TOOL == 'iar':
 if os.getenv('RTT_EXEC_PATH'):
     EXEC_PATH = os.getenv('RTT_EXEC_PATH')
 
-BUILD = 'release'
+BUILD = 'debug'
 
 if PLATFORM == 'gcc':
     # toolchains
@@ -52,7 +64,7 @@ if PLATFORM == 'gcc':
     LPATH = ''
 
     if BUILD == 'debug':
-        CFLAGS += ' -O1 -gdwarf-2 -g'
+        CFLAGS += ' -O0 -gdwarf-2 -g'
         AFLAGS += ' -gdwarf-2'
     else:
         CFLAGS += ' -O2'
@@ -73,7 +85,7 @@ elif PLATFORM == 'armcc':
     DEVICE = ' --cpu Cortex-M4.fp '
     CFLAGS = '-c ' + DEVICE + ' --apcs=interwork --c99'
     AFLAGS = DEVICE + ' --apcs=interwork '
-    LFLAGS = DEVICE + ' --scatter "board\linker_scripts\link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
+    LFLAGS = DEVICE + ' --scatter "board/linker_scripts/link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
     CFLAGS += ' -I' + EXEC_PATH + '/ARM/ARMCC/include'
     LFLAGS += ' --libpath=' + EXEC_PATH + '/ARM/ARMCC/lib'
 
@@ -121,7 +133,6 @@ elif PLATFORM == 'armclang':
         AFLAGS += ' -g'
     else:
         CFLAGS += ' -O2'
-        
     CXXFLAGS = CFLAGS
     CFLAGS += ' -std=c99'
 
@@ -172,7 +183,6 @@ elif PLATFORM == 'iccarm':
     LFLAGS += ' --entry __iar_program_start'
 
     CXXFLAGS = CFLAGS
-    
     EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool --bin $TARGET rtthread.bin'
 

--- a/projects/06_demo_lvgl/rtconfig.py
+++ b/projects/06_demo_lvgl/rtconfig.py
@@ -1,5 +1,7 @@
 import os
+import platform
 
+system_name = platform.system()
 # toolchains options
 ARCH='arm'
 CPU='cortex-m4'
@@ -15,9 +17,19 @@ if os.getenv('RTT_ROOT'):
 
 # cross_tool provides the cross compiler
 # EXEC_PATH is the compiler execute path, for example, CodeSourcery, Keil MDK, IAR
-if  CROSS_TOOL == 'gcc':
-    PLATFORM    = 'gcc'
-    EXEC_PATH   = r'C:\Users\XXYYZZ'
+if CROSS_TOOL == "gcc":
+    PLATFORM = "gcc"
+    # Linux
+    if system_name == "Linux":
+        EXEC_PATH = r"/usr/bin"
+    # Macos
+    elif system_name == "Darwin":
+        EXEC_PATH = r"/opt/homebrew/bin/"
+    # Windows
+    elif system_name == "Windows":
+        EXEC_PATH = r"C:\Users\XXYYZZ"
+    else:
+        EXEC_PATH = r"/usr/bin"
 elif CROSS_TOOL == 'keil':
     PLATFORM    = 'armcc'
     EXEC_PATH   = r'C:/Keil_v5'
@@ -28,7 +40,7 @@ elif CROSS_TOOL == 'iar':
 if os.getenv('RTT_EXEC_PATH'):
     EXEC_PATH = os.getenv('RTT_EXEC_PATH')
 
-BUILD = 'release'
+BUILD = 'debug'
 
 if PLATFORM == 'gcc':
     # toolchains
@@ -73,7 +85,7 @@ elif PLATFORM == 'armcc':
     DEVICE = ' --cpu Cortex-M4.fp '
     CFLAGS = '-c ' + DEVICE + ' --apcs=interwork --c99'
     AFLAGS = DEVICE + ' --apcs=interwork '
-    LFLAGS = DEVICE + ' --scatter "board\linker_scripts\link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
+    LFLAGS = DEVICE + ' --scatter "board/linker_scripts/link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
     CFLAGS += ' -I' + EXEC_PATH + '/ARM/ARMCC/include'
     LFLAGS += ' --libpath=' + EXEC_PATH + '/ARM/ARMCC/lib'
 
@@ -121,7 +133,6 @@ elif PLATFORM == 'armclang':
         AFLAGS += ' -g'
     else:
         CFLAGS += ' -O2'
-        
     CXXFLAGS = CFLAGS
     CFLAGS += ' -std=c99'
 
@@ -172,7 +183,6 @@ elif PLATFORM == 'iccarm':
     LFLAGS += ' --entry __iar_program_start'
 
     CXXFLAGS = CFLAGS
-    
     EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool --bin $TARGET rtthread.bin'
 

--- a/projects/06_demo_micropython/rtconfig.py
+++ b/projects/06_demo_micropython/rtconfig.py
@@ -1,5 +1,7 @@
 import os
+import platform
 
+system_name = platform.system()
 # toolchains options
 ARCH='arm'
 CPU='cortex-m4'
@@ -15,9 +17,19 @@ if os.getenv('RTT_ROOT'):
 
 # cross_tool provides the cross compiler
 # EXEC_PATH is the compiler execute path, for example, CodeSourcery, Keil MDK, IAR
-if  CROSS_TOOL == 'gcc':
-    PLATFORM    = 'gcc'
-    EXEC_PATH   = r'C:\Users\XXYYZZ'
+if CROSS_TOOL == "gcc":
+    PLATFORM = "gcc"
+    # Linux
+    if system_name == "Linux":
+        EXEC_PATH = r"/usr/bin"
+    # Macos
+    elif system_name == "Darwin":
+        EXEC_PATH = r"/opt/homebrew/bin/"
+    # Windows
+    elif system_name == "Windows":
+        EXEC_PATH = r"C:\Users\XXYYZZ"
+    else:
+        EXEC_PATH = r"/usr/bin"
 elif CROSS_TOOL == 'keil':
     PLATFORM    = 'armcc'
     EXEC_PATH   = r'C:/Keil_v5'
@@ -73,7 +85,7 @@ elif PLATFORM == 'armcc':
     DEVICE = ' --cpu Cortex-M4.fp '
     CFLAGS = '-c ' + DEVICE + ' --apcs=interwork --c99'
     AFLAGS = DEVICE + ' --apcs=interwork '
-    LFLAGS = DEVICE + ' --scatter "board\linker_scripts\link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
+    LFLAGS = DEVICE + ' --scatter "board/linker_scripts/link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
     CFLAGS += ' -I' + EXEC_PATH + '/ARM/ARMCC/include'
     LFLAGS += ' --libpath=' + EXEC_PATH + '/ARM/ARMCC/lib'
 
@@ -121,7 +133,6 @@ elif PLATFORM == 'armclang':
         AFLAGS += ' -g'
     else:
         CFLAGS += ' -O2'
-        
     CXXFLAGS = CFLAGS
     CFLAGS += ' -std=c99'
 
@@ -172,7 +183,6 @@ elif PLATFORM == 'iccarm':
     LFLAGS += ' --entry __iar_program_start'
 
     CXXFLAGS = CFLAGS
-    
     EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool --bin $TARGET rtthread.bin'
 

--- a/projects/06_demo_nes_simulator/rtconfig.py
+++ b/projects/06_demo_nes_simulator/rtconfig.py
@@ -1,5 +1,7 @@
 import os
+import platform
 
+system_name = platform.system()
 # toolchains options
 ARCH='arm'
 CPU='cortex-m4'
@@ -15,9 +17,19 @@ if os.getenv('RTT_ROOT'):
 
 # cross_tool provides the cross compiler
 # EXEC_PATH is the compiler execute path, for example, CodeSourcery, Keil MDK, IAR
-if  CROSS_TOOL == 'gcc':
-    PLATFORM    = 'gcc'
-    EXEC_PATH   = r'C:\Users\XXYYZZ'
+if CROSS_TOOL == "gcc":
+    PLATFORM = "gcc"
+    # Linux
+    if system_name == "Linux":
+        EXEC_PATH = r"/usr/bin"
+    # Macos
+    elif system_name == "Darwin":
+        EXEC_PATH = r"/opt/homebrew/bin/"
+    # Windows
+    elif system_name == "Windows":
+        EXEC_PATH = r"C:\Users\XXYYZZ"
+    else:
+        EXEC_PATH = r"/usr/bin"
 elif CROSS_TOOL == 'keil':
     PLATFORM    = 'armcc'
     EXEC_PATH   = r'C:/Keil_v5'
@@ -52,7 +64,7 @@ if PLATFORM == 'gcc':
     LPATH = ''
 
     if BUILD == 'debug':
-        CFLAGS += ' -O2 -gdwarf-2 -g'
+        CFLAGS += ' -O0 -gdwarf-2 -g'
         AFLAGS += ' -gdwarf-2'
     else:
         CFLAGS += ' -O2'
@@ -73,7 +85,7 @@ elif PLATFORM == 'armcc':
     DEVICE = ' --cpu Cortex-M4.fp '
     CFLAGS = '-c ' + DEVICE + ' --apcs=interwork --c99'
     AFLAGS = DEVICE + ' --apcs=interwork '
-    LFLAGS = DEVICE + ' --scatter "board\linker_scripts\link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
+    LFLAGS = DEVICE + ' --scatter "board/linker_scripts/link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
     CFLAGS += ' -I' + EXEC_PATH + '/ARM/ARMCC/include'
     LFLAGS += ' --libpath=' + EXEC_PATH + '/ARM/ARMCC/lib'
 
@@ -121,7 +133,6 @@ elif PLATFORM == 'armclang':
         AFLAGS += ' -g'
     else:
         CFLAGS += ' -O2'
-        
     CXXFLAGS = CFLAGS
     CFLAGS += ' -std=c99'
 
@@ -172,7 +183,6 @@ elif PLATFORM == 'iccarm':
     LFLAGS += ' --entry __iar_program_start'
 
     CXXFLAGS = CFLAGS
-    
     EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool --bin $TARGET rtthread.bin'
 

--- a/projects/06_demo_rs485_led_matrix/rtconfig.py
+++ b/projects/06_demo_rs485_led_matrix/rtconfig.py
@@ -1,5 +1,7 @@
 import os
+import platform
 
+system_name = platform.system()
 # toolchains options
 ARCH='arm'
 CPU='cortex-m4'
@@ -15,9 +17,19 @@ if os.getenv('RTT_ROOT'):
 
 # cross_tool provides the cross compiler
 # EXEC_PATH is the compiler execute path, for example, CodeSourcery, Keil MDK, IAR
-if  CROSS_TOOL == 'gcc':
-    PLATFORM    = 'gcc'
-    EXEC_PATH   = r'C:\Users\XXYYZZ'
+if CROSS_TOOL == "gcc":
+    PLATFORM = "gcc"
+    # Linux
+    if system_name == "Linux":
+        EXEC_PATH = r"/usr/bin"
+    # Macos
+    elif system_name == "Darwin":
+        EXEC_PATH = r"/opt/homebrew/bin/"
+    # Windows
+    elif system_name == "Windows":
+        EXEC_PATH = r"C:\Users\XXYYZZ"
+    else:
+        EXEC_PATH = r"/usr/bin"
 elif CROSS_TOOL == 'keil':
     PLATFORM    = 'armcc'
     EXEC_PATH   = r'C:/Keil_v5'
@@ -73,7 +85,7 @@ elif PLATFORM == 'armcc':
     DEVICE = ' --cpu Cortex-M4.fp '
     CFLAGS = '-c ' + DEVICE + ' --apcs=interwork --c99'
     AFLAGS = DEVICE + ' --apcs=interwork '
-    LFLAGS = DEVICE + ' --scatter "board\linker_scripts\link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
+    LFLAGS = DEVICE + ' --scatter "board/linker_scripts/link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
     CFLAGS += ' -I' + EXEC_PATH + '/ARM/ARMCC/include'
     LFLAGS += ' --libpath=' + EXEC_PATH + '/ARM/ARMCC/lib'
 
@@ -121,7 +133,6 @@ elif PLATFORM == 'armclang':
         AFLAGS += ' -g'
     else:
         CFLAGS += ' -O2'
-        
     CXXFLAGS = CFLAGS
     CFLAGS += ' -std=c99'
 
@@ -172,7 +183,6 @@ elif PLATFORM == 'iccarm':
     LFLAGS += ' --entry __iar_program_start'
 
     CXXFLAGS = CFLAGS
-    
     EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool --bin $TARGET rtthread.bin'
 

--- a/projects/06_demo_wavplayer/rtconfig.py
+++ b/projects/06_demo_wavplayer/rtconfig.py
@@ -1,5 +1,7 @@
 import os
+import platform
 
+system_name = platform.system()
 # toolchains options
 ARCH='arm'
 CPU='cortex-m4'
@@ -15,9 +17,19 @@ if os.getenv('RTT_ROOT'):
 
 # cross_tool provides the cross compiler
 # EXEC_PATH is the compiler execute path, for example, CodeSourcery, Keil MDK, IAR
-if  CROSS_TOOL == 'gcc':
-    PLATFORM    = 'gcc'
-    EXEC_PATH   = r'C:\Users\XXYYZZ'
+if CROSS_TOOL == "gcc":
+    PLATFORM = "gcc"
+    # Linux
+    if system_name == "Linux":
+        EXEC_PATH = r"/usr/bin"
+    # Macos
+    elif system_name == "Darwin":
+        EXEC_PATH = r"/opt/homebrew/bin/"
+    # Windows
+    elif system_name == "Windows":
+        EXEC_PATH = r"C:\Users\XXYYZZ"
+    else:
+        EXEC_PATH = r"/usr/bin"
 elif CROSS_TOOL == 'keil':
     PLATFORM    = 'armcc'
     EXEC_PATH   = r'C:/Keil_v5'
@@ -73,7 +85,7 @@ elif PLATFORM == 'armcc':
     DEVICE = ' --cpu Cortex-M4.fp '
     CFLAGS = '-c ' + DEVICE + ' --apcs=interwork --c99'
     AFLAGS = DEVICE + ' --apcs=interwork '
-    LFLAGS = DEVICE + ' --scatter "board\linker_scripts\link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
+    LFLAGS = DEVICE + ' --scatter "board/linker_scripts/link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
     CFLAGS += ' -I' + EXEC_PATH + '/ARM/ARMCC/include'
     LFLAGS += ' --libpath=' + EXEC_PATH + '/ARM/ARMCC/lib'
 
@@ -121,7 +133,6 @@ elif PLATFORM == 'armclang':
         AFLAGS += ' -g'
     else:
         CFLAGS += ' -O2'
-        
     CXXFLAGS = CFLAGS
     CFLAGS += ' -std=c99'
 
@@ -172,7 +183,6 @@ elif PLATFORM == 'iccarm':
     LFLAGS += ' --entry __iar_program_start'
 
     CXXFLAGS = CFLAGS
-    
     EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool --bin $TARGET rtthread.bin'
 

--- a/projects/07_module_key_matrix/rtconfig.py
+++ b/projects/07_module_key_matrix/rtconfig.py
@@ -1,5 +1,7 @@
 import os
+import platform
 
+system_name = platform.system()
 # toolchains options
 ARCH='arm'
 CPU='cortex-m4'
@@ -15,9 +17,19 @@ if os.getenv('RTT_ROOT'):
 
 # cross_tool provides the cross compiler
 # EXEC_PATH is the compiler execute path, for example, CodeSourcery, Keil MDK, IAR
-if  CROSS_TOOL == 'gcc':
-    PLATFORM    = 'gcc'
-    EXEC_PATH   = r'C:\Users\XXYYZZ'
+if CROSS_TOOL == "gcc":
+    PLATFORM = "gcc"
+    # Linux
+    if system_name == "Linux":
+        EXEC_PATH = r"/usr/bin"
+    # Macos
+    elif system_name == "Darwin":
+        EXEC_PATH = r"/opt/homebrew/bin/"
+    # Windows
+    elif system_name == "Windows":
+        EXEC_PATH = r"C:\Users\XXYYZZ"
+    else:
+        EXEC_PATH = r"/usr/bin"
 elif CROSS_TOOL == 'keil':
     PLATFORM    = 'armcc'
     EXEC_PATH   = r'C:/Keil_v5'
@@ -73,7 +85,7 @@ elif PLATFORM == 'armcc':
     DEVICE = ' --cpu Cortex-M4.fp '
     CFLAGS = '-c ' + DEVICE + ' --apcs=interwork --c99'
     AFLAGS = DEVICE + ' --apcs=interwork '
-    LFLAGS = DEVICE + ' --scatter "board\linker_scripts\link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
+    LFLAGS = DEVICE + ' --scatter "board/linker_scripts/link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
     CFLAGS += ' -I' + EXEC_PATH + '/ARM/ARMCC/include'
     LFLAGS += ' --libpath=' + EXEC_PATH + '/ARM/ARMCC/lib'
 
@@ -121,7 +133,6 @@ elif PLATFORM == 'armclang':
         AFLAGS += ' -g'
     else:
         CFLAGS += ' -O2'
-        
     CXXFLAGS = CFLAGS
     CFLAGS += ' -std=c99'
 
@@ -172,7 +183,6 @@ elif PLATFORM == 'iccarm':
     LFLAGS += ' --entry __iar_program_start'
 
     CXXFLAGS = CFLAGS
-    
     EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool --bin $TARGET rtthread.bin'
 

--- a/projects/07_module_spi_eth_enc28j60/rtconfig.py
+++ b/projects/07_module_spi_eth_enc28j60/rtconfig.py
@@ -1,5 +1,7 @@
 import os
+import platform
 
+system_name = platform.system()
 # toolchains options
 ARCH='arm'
 CPU='cortex-m4'
@@ -15,9 +17,19 @@ if os.getenv('RTT_ROOT'):
 
 # cross_tool provides the cross compiler
 # EXEC_PATH is the compiler execute path, for example, CodeSourcery, Keil MDK, IAR
-if  CROSS_TOOL == 'gcc':
-    PLATFORM    = 'gcc'
-    EXEC_PATH   = r'C:\Users\XXYYZZ'
+if CROSS_TOOL == "gcc":
+    PLATFORM = "gcc"
+    # Linux
+    if system_name == "Linux":
+        EXEC_PATH = r"/usr/bin"
+    # Macos
+    elif system_name == "Darwin":
+        EXEC_PATH = r"/opt/homebrew/bin/"
+    # Windows
+    elif system_name == "Windows":
+        EXEC_PATH = r"C:\Users\XXYYZZ"
+    else:
+        EXEC_PATH = r"/usr/bin"
 elif CROSS_TOOL == 'keil':
     PLATFORM    = 'armcc'
     EXEC_PATH   = r'C:/Keil_v5'
@@ -73,7 +85,7 @@ elif PLATFORM == 'armcc':
     DEVICE = ' --cpu Cortex-M4.fp '
     CFLAGS = '-c ' + DEVICE + ' --apcs=interwork --c99'
     AFLAGS = DEVICE + ' --apcs=interwork '
-    LFLAGS = DEVICE + ' --scatter "board\linker_scripts\link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
+    LFLAGS = DEVICE + ' --scatter "board/linker_scripts/link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
     CFLAGS += ' -I' + EXEC_PATH + '/ARM/ARMCC/include'
     LFLAGS += ' --libpath=' + EXEC_PATH + '/ARM/ARMCC/lib'
 
@@ -121,7 +133,6 @@ elif PLATFORM == 'armclang':
         AFLAGS += ' -g'
     else:
         CFLAGS += ' -O2'
-        
     CXXFLAGS = CFLAGS
     CFLAGS += ' -std=c99'
 
@@ -172,7 +183,6 @@ elif PLATFORM == 'iccarm':
     LFLAGS += ' --entry __iar_program_start'
 
     CXXFLAGS = CFLAGS
-    
     EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool --bin $TARGET rtthread.bin'
 

--- a/projects/07_module_ultrasonic_sr04/rtconfig.py
+++ b/projects/07_module_ultrasonic_sr04/rtconfig.py
@@ -1,5 +1,7 @@
 import os
+import platform
 
+system_name = platform.system()
 # toolchains options
 ARCH='arm'
 CPU='cortex-m4'
@@ -15,9 +17,19 @@ if os.getenv('RTT_ROOT'):
 
 # cross_tool provides the cross compiler
 # EXEC_PATH is the compiler execute path, for example, CodeSourcery, Keil MDK, IAR
-if  CROSS_TOOL == 'gcc':
-    PLATFORM    = 'gcc'
-    EXEC_PATH   = r'C:\Users\XXYYZZ'
+if CROSS_TOOL == "gcc":
+    PLATFORM = "gcc"
+    # Linux
+    if system_name == "Linux":
+        EXEC_PATH = r"/usr/bin"
+    # Macos
+    elif system_name == "Darwin":
+        EXEC_PATH = r"/opt/homebrew/bin/"
+    # Windows
+    elif system_name == "Windows":
+        EXEC_PATH = r"C:\Users\XXYYZZ"
+    else:
+        EXEC_PATH = r"/usr/bin"
 elif CROSS_TOOL == 'keil':
     PLATFORM    = 'armcc'
     EXEC_PATH   = r'C:/Keil_v5'
@@ -73,7 +85,7 @@ elif PLATFORM == 'armcc':
     DEVICE = ' --cpu Cortex-M4.fp '
     CFLAGS = '-c ' + DEVICE + ' --apcs=interwork --c99'
     AFLAGS = DEVICE + ' --apcs=interwork '
-    LFLAGS = DEVICE + ' --scatter "board\linker_scripts\link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
+    LFLAGS = DEVICE + ' --scatter "board/linker_scripts/link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
     CFLAGS += ' -I' + EXEC_PATH + '/ARM/ARMCC/include'
     LFLAGS += ' --libpath=' + EXEC_PATH + '/ARM/ARMCC/lib'
 
@@ -121,7 +133,6 @@ elif PLATFORM == 'armclang':
         AFLAGS += ' -g'
     else:
         CFLAGS += ' -O2'
-        
     CXXFLAGS = CFLAGS
     CFLAGS += ' -std=c99'
 
@@ -172,7 +183,6 @@ elif PLATFORM == 'iccarm':
     LFLAGS += ' --entry __iar_program_start'
 
     CXXFLAGS = CFLAGS
-    
     EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool --bin $TARGET rtthread.bin'
 

--- a/projects/07_module_ws2812_led/rtconfig.py
+++ b/projects/07_module_ws2812_led/rtconfig.py
@@ -1,5 +1,7 @@
 import os
+import platform
 
+system_name = platform.system()
 # toolchains options
 ARCH='arm'
 CPU='cortex-m4'
@@ -15,9 +17,19 @@ if os.getenv('RTT_ROOT'):
 
 # cross_tool provides the cross compiler
 # EXEC_PATH is the compiler execute path, for example, CodeSourcery, Keil MDK, IAR
-if  CROSS_TOOL == 'gcc':
-    PLATFORM    = 'gcc'
-    EXEC_PATH   = r'C:\Users\XXYYZZ'
+if CROSS_TOOL == "gcc":
+    PLATFORM = "gcc"
+    # Linux
+    if system_name == "Linux":
+        EXEC_PATH = r"/usr/bin"
+    # Macos
+    elif system_name == "Darwin":
+        EXEC_PATH = r"/opt/homebrew/bin/"
+    # Windows
+    elif system_name == "Windows":
+        EXEC_PATH = r"C:\Users\XXYYZZ"
+    else:
+        EXEC_PATH = r"/usr/bin"
 elif CROSS_TOOL == 'keil':
     PLATFORM    = 'armcc'
     EXEC_PATH   = r'C:/Keil_v5'
@@ -73,7 +85,7 @@ elif PLATFORM == 'armcc':
     DEVICE = ' --cpu Cortex-M4.fp '
     CFLAGS = '-c ' + DEVICE + ' --apcs=interwork --c99'
     AFLAGS = DEVICE + ' --apcs=interwork '
-    LFLAGS = DEVICE + ' --scatter "board\linker_scripts\link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
+    LFLAGS = DEVICE + ' --scatter "board/linker_scripts/link.sct" --info sizes --info totals --info unused --info veneers --list rt-thread.map --strict'
     CFLAGS += ' -I' + EXEC_PATH + '/ARM/ARMCC/include'
     LFLAGS += ' --libpath=' + EXEC_PATH + '/ARM/ARMCC/lib'
 
@@ -121,7 +133,6 @@ elif PLATFORM == 'armclang':
         AFLAGS += ' -g'
     else:
         CFLAGS += ' -O2'
-        
     CXXFLAGS = CFLAGS
     CFLAGS += ' -std=c99'
 
@@ -172,7 +183,6 @@ elif PLATFORM == 'iccarm':
     LFLAGS += ' --entry __iar_program_start'
 
     CXXFLAGS = CFLAGS
-    
     EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool --bin $TARGET rtthread.bin'
 


### PR DESCRIPTION
加入了 platform 判断，检测到 Linux/Macos 的时候使用 /usr/bin 和 /opt/homebrew/bin/ 路径，确保正确找到工具链并成功编译